### PR TITLE
Implement the same replacements feature/parameter that minetest.place_schematic() provides.

### DIFF
--- a/plan.lua
+++ b/plan.lua
@@ -215,7 +215,8 @@ end
 --------------------------------------
 -- Generate a plan from schematics file
 --------------------------------------
-function plan_class:read_from_schem_file(filename)
+-- replacements parameter is optional, and only used by .mts files.
+function plan_class:read_from_schem_file(filename, replacements)
 
 	local mts_format = string.find(filename, '.mts',  -4)
 
@@ -261,6 +262,7 @@ function plan_class:read_from_schem_file(filename)
 		for i = 1, node_name_count do
 			local name_length = read_s16(file)
 			local name_text   = file:read(name_length)
+			if replacements ~= nil and replacements[name_text] ~= nil then name_text = replacements[name_text] end
 			table.insert(node_names, name_text)
 			if name_text == "air" then
 				air_id = i


### PR DESCRIPTION
This pull request may be a product of me not understanding how to properly use schemlib, and it might not be in line with what you want to do with schemlib...

I've added schemlib support to a mod because schemlib doesn't have [the bug](https://forum.minetest.net/viewtopic.php?t=22136) that `minetest.place_schematic()` has had for years.

However, some node types in the schematic need to be replaced, and as far as I could tell, schemlib doesn't have a good way of doing this - its replacements are built-in and not exposed. [I solved it by writing my replacement mappings directly into the plan_obj.mapping_cache](https://github.com/Treer/cloudlands/blob/bef13b149594f91bbb8e949a72a62a2920016fd3/cloudlands.lua#L725), which works, but this is probably not what you envisioned.

I was also concerned about the speed hit from every node needing to run through `node_class:get_mapped()`, when the mapping can be done just once per node type as the .mts is loaded (i.e. what this pull request allows), but it looks like this change won't offer a speed advantage as it looks like the nodes will still add their types to the mapping_cache and invoke `node_class:get_mapped()` anyway?

What would be the appropriate way for a mod to transform node types in schemlib?

